### PR TITLE
Add Requests Cache

### DIFF
--- a/nba_api/library/http.py
+++ b/nba_api/library/http.py
@@ -1,7 +1,9 @@
 import os
 import json
 import requests
+import requests_cache
 
+requests_cache.install_cache('nba_api_cache')
 
 try:
     from nba_api.library.debug.debug import DEBUG

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="Swar Patel",
     author_email="swar.m.patel@gmail.com",
     description="An API Client package to access the APIs for NBA.com",
-    install_requires=["requests"],
+    install_requires=["requests", "requests_cache"],
     keywords='nba api sports data basketball stats',
     license="MIT",
     long_description=long_description,


### PR DESCRIPTION
## PR Objective:
Add requests cache to nba_api to cache requests made to the public API

## What Changed:
* Added requests_cache to the setup.py
* Added requests_cache setup to the http.py file

## Technical Reasoning for Changes:
We want to cache the API requests to NBA's api to speed up multiple calls to same endpoint. To accomplish this we drop a plug and play package of `requests_cache` from https://github.com/reclosedev/requests-cache