### PR TITLE
Updates for VSCode, Snyk, and Python Versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2.0
+version: 2.1
+
+orbs: 
+  snyk: snyk/snyk@1.1.2
 
 flake8-steps: &steps
   - checkout
@@ -13,19 +16,10 @@ flake8-steps: &steps
   - run: pip install --user pytest
   - run: python -m pytest  tests/stats/library/playbyplay/test_play_by_play_regex.py
   - run: python -m pytest  tests/live/endpoints
+  - snyk/scan:
+      target-file: setup.py
 
-  
 jobs:
-  Python34:
-    docker:
-      - image: circleci/python:3.4
-    steps: *steps
-
-  Python35:
-    docker:
-      - image: circleci/python:3.5
-    steps: *steps
-
   Python36:
     docker:
       - image: circleci/python:3.6
@@ -46,13 +40,17 @@ jobs:
       - image: circleci/python:3.9
     steps: *steps
 
+  Python310:
+    docker:
+      - image: circleci/python:3.10
+    steps: *steps
+
 workflows:
   version: 2
   build:
     jobs:
-      - Python34
-      - Python35
       - Python36
       - Python37
       - Python38
       - Python39
+      - Python310

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import setuptools
+from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(
+setup(
     name="nba_api",
     version="1.1.11",
     author="Swar Patel",


### PR DESCRIPTION
Added Snyk Support in Build
Dropped Support for Python 3.4 & 3.5 as they are retired
Updated shared settings for VSCode.