### PR TITLE
PlayByPlay Regex Fixes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -46,6 +46,8 @@
 
 - [Issue #249](https://github.com/swar/nba_api/issues/249)
   - `./nba_api/stats/endpoints/_base.py` requires `numpy` to format data for `get_data_frame`. Added `numpy` to `setup.py` `install_requires` directive.
+- [Issue #278](https://github.com/swar/nba_api/issues/278)
+  - Fixed `playbyplayregex` where the NBA removed a space that represented `distance` when `distance` was not included in the made/missed shot.
 
 ### v1.1.11
 

--- a/src/nba_api/stats/library/playbyplayregex.py
+++ b/src/nba_api/stats/library/playbyplayregex.py
@@ -18,8 +18,8 @@ pattern_turnover_team = r'^(?P<team>\w+( \w+)?) Turnover: (?P<turnover_type>.*) 
 pattern_timeout = r'^(?P<team>\w+( \w+)?) Timeout: ((?P<timeout_type>.*)) \(\w+( |\.)(?P<full>\d+) \w+ (?P<short>\d+)\)$'
 pattern_block = r"^(?P<player>.+) BLOCK \((?P<blocks>\d+) BLK\)$"                    
 pattern_ejection = r'^(?P<player>.+) Ejection:(?P<ejection_type>.*)$'
-pattern_field_goal_made = r"^(?P<player>.+) (((?P<distance>\d+)\' )| )(?P<field_goal_type>[\w+( |\-)]*) \((?P<points>\d+) PTS\)( \((?P<player_ast>\D+) (?P<assists>\d+) AST\))?$"
-pattern_field_goal_missed = r"^MISS (?P<player>.+) (((?P<distance>\d+)\' )| )(?P<field_goal_type>[\w+( |\-)]*)$"
+pattern_field_goal_made = r"^{player} (((?P<distance>\d+)\' )| )?[ ]*(?P<field_goal_type>[\w+( |\-)]*) \((?P<points>\d+) PTS\)( \((?P<player_ast>\D+) (?P<assists>\d+) AST\))?$".format(player=pattern_player)
+pattern_field_goal_missed = r"^MISS {player} ((?P<distance>\d+)\' )?[ ]*(?P<field_goal_type>[\w+( |\-)]*)$".format(player=pattern_player)
 pattern_foul_player = r"^(?P<player>.+) (?P<foul_type>.*)\s(?=(\(\w+(?P<personal>\d+)(\.\w+(?P<team>[\d|\w]+))?\)( \((?P<referee>.*)\))?)$)"
 pattern_foul_team = r"^(?P<team>\w+( \w+)?) T.Foul \((?P<foul_type>.*) (?P<player>.+) \) (\((?P<referee>.*)\))"
 pattern_free_throw_made = r"^(?P<player>.+) Free Throw (?P<free_throw_type>(.* )?(\d of \d)|\w+) \((?P<points>\d+) PTS\)$"

--- a/tests/unit/data_playbyplayregex.py
+++ b/tests/unit/data_playbyplayregex.py
@@ -19,11 +19,17 @@ playbyplay["FieldGoalMade"].append({"description" : "Aldridge 6' Turnaround Hook
 #Field Goal Made (Without Distance & With Double Space)
 playbyplay["FieldGoalMade"].append({"description" : "Broekhoff  3PT Jump Shot (3 PTS) (Lee 2 AST)", "player" : "Broekhoff", "distance" : None, "field_goal_type" : "3PT Jump Shot", "points" : "3", "player_ast" : "Lee", "assists" : "2"})
 
+#Field Goal Made (Without Distance & With Single Space)
+playbyplay["FieldGoalMade"].append({"description" : "Portis Tip Layup Shot (5 PTS)", "player" : "Portis", "distance" : None, "field_goal_type" : "Tip Layup Shot", "points" : "5", "player_ast" : None, "assists" : None})
+
 #Field Goal Missed
 playbyplay["FieldGoalMissed"].append({"description" : "MISS O'Quinn 17' Jump Shot", "player" : "O'Quinn", "distance" : "17", "field_goal_type" : "Jump Shot"})
 
 #Field Goal Missed (Without Disstance & With Double Space)
 playbyplay["FieldGoalMissed"].append({"description" : "MISS O'Quinn  3PT Jump Shot", "player" : "O'Quinn", "distance" : None, "field_goal_type" : "3PT Jump Shot"})
+
+#Field Goal Missed (Without Disstance & With Single Space)
+playbyplay["FieldGoalMissed"].append({"description" : "MISS O'Quinn 3PT Jump Shot", "player" : "O'Quinn", "distance" : None, "field_goal_type" : "3PT Jump Shot"})
 
 #Foul Player
 playbyplay["FoulPlayer"].append({"description" : "Collison P.FOUL (P1.TN) (M.Lindsay)", "player" : "Collison", "foul_type" : "P.FOUL", "personal" : "1", "team" : "N", "referee" : "M.Lindsay"})


### PR DESCRIPTION
Fixed `playbyplayregex` where the NBA removed a `space` that represented `distance' when `distance` was not included in the made/missed shot.