### PR TITLE
Dynamically set the PYTHON_PATH env within the Dev Container for Poetry.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,13 @@
 {
 	"containerEnv": {
-		"PYTHON_VERSION": "3.11",
-		"PYTHON_PATH": ""
+		"PYTHON_VERSION": "3.11"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/python:latest": {
-			"version": "3.11"
-		},
+		"ghcr.io/devcontainers/features/python:latest": {},
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {}
 	},
 	"image": "mcr.microsoft.com/devcontainers/base:debian",
-	"name": "nba_data",
+	"name": "nba_api",
 	"postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
 	"remoteEnv": {
 		"PYTHONUTF8": "1"
@@ -18,7 +15,12 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-python.python"
+				"ms-python.python",
+				"ms-toolsai.jupyter-keymap",
+				"ms-python.black-formatter",
+				"ms-toolsai.jupyter",
+				"ms-toolsai.vscode-jupyter-powertoys",
+				"ms-toolsai.jupyter-renderers"
 			]
 		}
 	}

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,5 +1,8 @@
-CONSTRAINT_URL=https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt
 pip install --upgrade pip
 poetry install --no-root
-# pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
-#(airflow standalone) &
+
+# Activate poetry environment
+source $(poetry env info --path)/bin/activate
+
+# Update PYTHONPATH to include the virtual environment's Python interpreter
+echo "export PYTHON_PATH=$(poetry env info --path)/bin/python" >> ~/.bashrc


### PR DESCRIPTION
PYTHON_PATH should be set to the active environment for Poetry. Since this can only be done once the environment is up, changes have been made to the postCreateCommand.sh file to set that during the dev container build.