### PR TITLE
Resolved CVE-2023-32681

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,12 @@
 - `Security` in case of vulnerabilities.
 
 # Version History
+## v1.3.1 (Draft)
+
+Date: TBD
+
+### Security
+Set minimum requirement for [requests](https://pypi.org/project/requests/) to 2.31 per [CVE-2023-32681](https://www.cve.org/CVERecord?id=CVE-2023-32681) / [CWE-200](https://cwe.mitre.org/data/definitions/200.html) 
 
 ## v1.3.0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -430,4 +430,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b4badcb5d51ac7ca00704fbdd6345e6a5096c0301ac851a2eba21a490d56c868"
+content-hash = "62dd3d4d0c381c975d08b3bface5903c21af8811a7bdfdf5b4f370d1ac0b5d52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-requests = "*"
+requests = "^2.31"
 numpy = "^1.22.2"
 
 [tool.poetry.urls]


### PR DESCRIPTION
 Since Requests 2.3.0, Requests has been leaking Proxy-Authorization headers to destination servers when redirected to an HTTPS endpoint. This is a product of how we use `rebuild_proxies` to reattach the `Proxy-Authorization` header to requests. For HTTP connections sent through the tunnel, the proxy will identify the header in the request itself and remove it prior to forwarding to the destination server. However when sent over HTTPS, the `Proxy-Authorization` header must be sent in the CONNECT request as the proxy has no visibility into the tunneled request. This results in Requests forwarding proxy credentials to the destination server unintentionally, allowing a malicious actor to potentially exfiltrate sensitive information. This issue has been patched in version 2.31.0.

https://www.cve.org/CVERecord?id=CVE-2023-32681