### PR TITLE
fix: update 18 as Instant Replay

### DIFF
--- a/src/nba_api/stats/library/eventmsgtype.py
+++ b/src/nba_api/stats/library/eventmsgtype.py
@@ -15,4 +15,4 @@ class EventMsgType(Enum):
     EJECTION = 11
     PERIOD_BEGIN = 12
     PERIOD_END = 13
-    UNKNOWN = 18
+    INSTANT_REPLAY = 18


### PR DESCRIPTION
## Summary
correct ID `18` to `Instant Replay`, instead of `UNKNOWN`

## Reference

Here is sample for a same event from `playbyplayv2` and `playbyplayv3` which GameID is `0042100212`. According to the comparison, `18` should be `Instant Replay`

* v2 (which eventmsgtype's index is 2)
```
[
    '0042100212',
    122,
    18,
    1,
    1,
    '7:19 PM',
    '2:46',
    None,
    'Instant Replay1st Period (7:19 PM EST)',
    None,
    '12 - 27',
    '15',
    0,
    0,
    None,
    None,
    None,
    None,
    None,
    0,
    0,
    None,
    None,
    None,
    None,
    None,
    0,
    0,
    None,
    None,
    None,
    None,
    None,
    0
]
```

* v3
```
{
  'actionNumber': 122,
  'clock': 'PT02M46.00S',
  'period': 1,
  'teamId': 0,
  'teamTricode': '',
  'personId': 0,
  'playerName': '',
  'playerNameI': '',
  'xLegacy': 0,
  'yLegacy': 0,
  'shotDistance': 0,
  'shotResult': '',
  'isFieldGoal': 0,
  'scoreHome': '27',
  'scoreAway': '12',
  'pointsTotal': 39,
  'location': '',
  'description': 'Instant Replay1st Period (7:19 PM EST)',
  'actionType': 'Instant Replay',
  'subType': 'Overturn Ruling',
  'videoAvailable': 0,
  'actionId': 78
}
```