### PR TITLE
add ISTStandings endpoint

### DIFF
--- a/analysis_archive/stats/analysis.json
+++ b/analysis_archive/stats/analysis.json
@@ -2801,6 +2801,79 @@
         ],
         "status": "success"
     },
+    "ISTStangings": {
+        "data_sets": {
+            "Standings": [
+                "leagueId",
+                "seasonYear",
+                "teamId",
+                "teamCity",
+                "teamName",
+                "teamAbbreviation",
+                "teamSlug",
+                "conference",
+                "istGroup",
+                "clinchIndicator",
+                "clinchedIstKnockout",
+                "clinchedIstGroup",
+                "clinchedIstWildcard",
+                "istWildcardRank",
+                "istGroupRank",
+                "istKnockoutRank",
+                "wins",
+                "losses",
+                "pct",
+                "istGroupGb",
+                "istWildcardGb",
+                "diff",
+                "pts",
+                "oppPts",
+                "gameId1",
+                "opponentTeamAbbreviation1",
+                "location1",
+                "gameStatus1",
+                "gameStatusText1",
+                "outcome1",
+                "gameId2",
+                "opponentTeamAbbreviation2",
+                "location2",
+                "gameStatus2",
+                "gameStatusText2",
+                "outcome2",
+                "gameId3",
+                "opponentTeamAbbreviation3",
+                "location3",
+                "gameStatus3",
+                "gameStatusText3",
+                "outcome3",
+                "gameId4",
+                "opponentTeamAbbreviation4",
+                "location4",
+                "gameStatus4",
+                "gameStatusText4",
+                "outcome4"
+            ]
+        },
+        "endpoint": "ISTStangings",
+        "last_validated_date": "2023-11-08",
+        "nullable_parameters": [],
+        "parameter_patterns": {
+            "GameID": "^\\d{2}$",
+            "Season": "^\\d{4}-\\d{2}$",
+            "Section": "^(group)|(widcard)$"
+        },
+        "parameters": [
+            "LeagueID",
+            "Season",
+            "Section"
+        ],
+        "required_parameters": [
+            "LeagueID",
+            "Season",
+            "Section"
+        ],
+        "status": "success"
+    },
     "LeadersTiles": {
         "data_sets": {
             "AllTimeSeasonHigh": [

--- a/docs/nba_api/stats/endpoints/iststandings.md
+++ b/docs/nba_api/stats/endpoints/iststandings.md
@@ -1,0 +1,102 @@
+# ISTStandings
+##### [nba_api/stats/endpoints/iststandings.py](https://github.com/swar/nba_api/blob/master/src/nba_api/stats/endpoints/idststandings.py)
+
+##### Endpoint URL
+>[https://stats.nba.com/stats/iststandings](https://stats.nba.com/stats/iststandings)
+
+##### Valid URL
+>[https://stats.nba.com/stats/iststandings?LeagueID=00&Season=2023-24&Section=group](https://stats.nba.com/stats/iststandings?LeagueID=00&Season=2023-24&Section=group)
+
+## Parameters
+| API Parameter Name                                                                                              | Python Parameter Variable |         Pattern         |  Required   | Nullable |
+|-----------------------------------------------------------------------------------------------------------------|---------------------------|:-----------------------:|:-----------:|:--------:|
+| [_**LeagueID**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#LeagueID) | league_id                 |        `^\d{2}$`        |     `Y`     |          | 
+| [_**Season**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#Season)     | season                    |                         |     `Y`     |          |
+| [_**Section**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#Section)   | section                   | `^(group)\|(wildcard)$` |     `Y`     |          |
+
+## Data Sets
+#### Standings `standings`
+```text
+["leagueId", "seasonYear", "teamId", "teamCity", "teamName", "teamAbbreviation", "teamSlug", "conference", "istGroup", "clinchIndicator", "clinchedIstKnockout", "clinchedIstGroup", "clinchedIstWildcard", "istWildcardRank", "istGroupRank", "istKnockoutRank", "wins", "losses", "pct", "istGroupGb", "istWildcardGb", "diff", "pts", "oppPts", "gameId1", "opponentTeamAbbreviation1", "location1", "gameStatus1", "gameStatusText1", "outcome1", "gameId2", "opponentTeamAbbreviation2", "location2", "gameStatus2", "gameStatusText2", "outcome2", "gameId3", "opponentTeamAbbreviation3", "location3", "gameStatus3", "gameStatusText3", "outcome3", "gameId4", "opponentTeamAbbreviation4", "location4", "gameStatus4", "gameStatusText4", "outcome4"]
+```
+
+
+## JSON
+```json
+{
+    "data_sets": {
+        "Standings": [
+            "leagueId",
+            "seasonYear",
+            "teamId",
+            "teamCity",
+            "teamName",
+            "teamAbbreviation",
+            "teamSlug",
+            "conference",
+            "istGroup",
+            "clinchIndicator",
+            "clinchedIstKnockout",
+            "clinchedIstGroup",
+            "clinchedIstWildcard",
+            "istWildcardRank",
+            "istGroupRank",
+            "istKnockoutRank",
+            "wins",
+            "losses",
+            "pct",
+            "istGroupGb",
+            "istWildcardGb",
+            "diff",
+            "pts",
+            "oppPts",
+            "gameId1",
+            "opponentTeamAbbreviation1",
+            "location1",
+            "gameStatus1",
+            "gameStatusText1",
+            "outcome1",
+            "gameId2",
+            "opponentTeamAbbreviation2",
+            "location2",
+            "gameStatus2",
+            "gameStatusText2",
+            "outcome2",
+            "gameId3",
+            "opponentTeamAbbreviation3",
+            "location3",
+            "gameStatus3",
+            "gameStatusText3",
+            "outcome3",
+            "gameId4",
+            "opponentTeamAbbreviation4",
+            "location4",
+            "gameStatus4",
+            "gameStatusText4",
+            "outcome4"
+        ]
+    },
+    "endpoint": "ISTStandings",
+    "last_validated_date": "2023-11-08",
+    "nullable_parameters": [
+    ],
+    "parameter_patterns": {
+        "LeagueID": "^\\d{2}$",
+        "Season": "^\\d{4}-\\d{2}$",
+        "Section": "^(group)|(wildcard)$"
+    },
+    "parameters": [
+        "LeagueID",
+        "Season",
+        "Section"
+    ],
+    "required_parameters": [
+        "LeagueID",
+        "Season",
+        "Section"
+    ],
+    "status": "success"
+}
+```
+
+Last validated 2023-11-08

--- a/docs/nba_api/stats/library/parameters.md
+++ b/docs/nba_api/stats/library/parameters.md
@@ -1990,6 +1990,18 @@ Variable Name | Value
 _**current_season_year**_ `default` | `2019`
 _**current_datetime**_ | `2020-08-16 17:10:16.971483`
 
+
+## _Section_
+##### Patterns 
+ - `^(group)|(widcard)$`
+
+Variable Name | Value
+------------ | -------------
+_**none**_ `default` | 
+_**group**_ | `group`
+_**wildcard**_ | `wildcard`
+
+
 ## _SeriesID_
 No available information.
 

--- a/src/nba_api/stats/endpoints/__init__.py
+++ b/src/nba_api/stats/endpoints/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "homepagev2",
     "hustlestatsboxscore",
     "infographicfanduelplayer",
+    "iststandings",
     "leaderstiles",
     "leaguedashlineups",
     "leaguedashplayerbiostats",
@@ -184,6 +185,7 @@ from .glalumboxscoresimilarityscore import GLAlumBoxScoreSimilarityScore
 from .homepageleaders import HomePageLeaders
 from .homepagev2 import HomePageV2
 from .hustlestatsboxscore import HustleStatsBoxScore
+from .iststandings import ISTStandings
 from .infographicfanduelplayer import InfographicFanDuelPlayer
 from .leaderstiles import LeadersTiles
 from .leaguedashlineups import LeagueDashLineups

--- a/src/nba_api/stats/endpoints/iststandings.py
+++ b/src/nba_api/stats/endpoints/iststandings.py
@@ -1,0 +1,103 @@
+from nba_api.stats.endpoints._base import Endpoint
+from nba_api.stats.library.http import NBAStatsHTTP
+from nba_api.stats.library.parameters import (
+    LeagueID, Season, Section
+)
+
+
+class ISTStandings(Endpoint):
+    endpoint = "iststandings"
+    expected_data = {
+        "Standings": [
+            "leagueId",
+            "seasonYear",
+            "teamId",
+            "teamCity",
+            "teamName",
+            "teamAbbreviation",
+            "teamSlug",
+            "conference",
+            "istGroup",
+            "clinchIndicator",
+            "clinchedIstKnockout",
+            "clinchedIstGroup",
+            "clinchedIstWildcard",
+            "istWildcardRank",
+            "istGroupRank",
+            "istKnockoutRank",
+            "wins",
+            "losses",
+            "pct",
+            "istGroupGb",
+            "istWildcardGb",
+            "diff",
+            "pts",
+            "oppPts",
+            "gameId1",
+            "opponentTeamAbbreviation1",
+            "location1",
+            "gameStatus1",
+            "gameStatusText1",
+            "outcome1",
+            "gameId2",
+            "opponentTeamAbbreviation2",
+            "location2",
+            "gameStatus2",
+            "gameStatusText2",
+            "outcome2",
+            "gameId3",
+            "opponentTeamAbbreviation3",
+            "location3",
+            "gameStatus3",
+            "gameStatusText3",
+            "outcome3",
+            "gameId4",
+            "opponentTeamAbbreviation4",
+            "location4",
+            "gameStatus4",
+            "gameStatusText4",
+            "outcome4"
+        ]
+    }
+
+    nba_response = None
+    data_sets = None
+    standings = None
+    headers = None
+
+    def __init__(
+        self,
+        league_id=LeagueID.default,
+        season=Season.default,
+        section = Section.default,
+        proxy=None,
+        headers=None,
+        timeout=30,
+        get_request=True,
+    ):
+        self.proxy = proxy
+        if headers is not None:
+            self.headers = headers
+        self.timeout = timeout
+        self.parameters = {
+            'LeagueID': league_id,
+            'Season': '20' + season,
+            'Section': section
+        }
+        if get_request:
+            self.get_request()
+
+    def get_request(self):
+        self.nba_response = NBAStatsHTTP().send_api_request(
+            endpoint=self.endpoint,
+            parameters=self.parameters,
+            proxy=self.proxy,
+            headers=self.headers,
+            timeout=self.timeout,
+        )
+        self.load_response()
+
+    def load_response(self):
+        data_sets = self.nba_response.get_data_sets(self.endpoint)
+        self.data_sets = [Endpoint.DataSet(data=data_set) for data_set_name, data_set in data_sets.items()]
+        self.standings = Endpoint.DataSet(data=data_sets['Standings'])

--- a/src/nba_api/stats/library/http.py
+++ b/src/nba_api/stats/library/http.py
@@ -5,6 +5,7 @@ from nba_api.stats.library.parserv3 import (
     NBAStatsBoxscoreTraditionalParserV3,
     NBAStatsBoxscoreMatchupsParserV3,
     NBAStatsPlayByPlayParserV3,
+    NBAStatsISTStandingsParser
 )
 
 
@@ -20,6 +21,7 @@ PARSER_DICT = {
     "boxscoretraditionalv3": NBAStatsBoxscoreTraditionalParserV3,
     "boxscoreusagev3": NBAStatsBoxscoreParserV3,
     "playbyplayv3": NBAStatsPlayByPlayParserV3,
+    "iststandings": NBAStatsISTStandingsParser
 }
 
 try:

--- a/src/nba_api/stats/library/parameters.py
+++ b/src/nba_api/stats/library/parameters.py
@@ -716,6 +716,13 @@ class SeasonSegmentNullable(_NotRequired, SeasonSegment):
     pass
 
 
+class Section:
+    group = 'group'
+    wildcard = 'wildcard'
+
+    default = group
+
+
 class ShotClockRange:
     def calculate_range(self, i):
         i = float(i)

--- a/src/nba_api/stats/library/parserv3.py
+++ b/src/nba_api/stats/library/parserv3.py
@@ -197,3 +197,42 @@ class NBAStatsPlayByPlayParserV3:
         results['PlayByPlay'] = {'headers': pbp_head, 'data': pbp_data}
         results['AvailableVideo'] = {'headers': [video_head], 'data': [[video_data]]}
         return results
+
+
+class NBAStatsISTStandingsParser:
+    def __init__(self, nba_dict):
+        self.nba_dict = nba_dict
+
+    def get_iststandings_headers(self):
+        team_header = [key for key, value in self.nba_dict['teams'][0].items() if key != 'games']
+        game_header = []
+        for game in self.nba_dict['teams'][0]['games']:
+            number = game['gameNumber']
+            for key, value in game.items():
+                if key == 'gameNumber':
+                    continue
+                header = key + str(number)
+                game_header.append(header)
+        return ['leagueId'] + ['seasonYear'] + team_header + game_header
+
+    def get_iststandings_data(self):
+        teams_data = []
+        for team in self.nba_dict['teams']:
+            team_value = []
+            t_data = [value for key, value in team.items() if key != 'games']
+            team_value.extend([self.nba_dict['leagueId'], self.nba_dict['seasonYear']])
+            team_value.extend(t_data)
+            for game in team['games']:
+                for key, value in game.items():
+                    if key == 'gameNumber':
+                        continue
+                    team_value.append(value)
+            teams_data.append(team_value)
+        return teams_data
+
+    def get_data_sets(self):
+        results = {'Standings': None}
+        iststandings_head = self.get_iststandings_headers()
+        iststandings_data = self.get_iststandings_data()
+        results['Standings'] = {'headers': iststandings_head, 'data': iststandings_data}
+        return results

--- a/tests/integration/deferred_endpoints.py
+++ b/tests/integration/deferred_endpoints.py
@@ -65,6 +65,7 @@ deferred_endpoints = [
     DeferredEndpoint(ep.HomePageV2),
     DeferredEndpoint(ep.HustleStatsBoxScore, game_id="0021700807"),
     DeferredEndpoint(ep.InfographicFanDuelPlayer, game_id="0021700807"),
+    DeferredEndpoint(ep.ISTStangings),
     DeferredEndpoint(ep.LeadersTiles),
     DeferredEndpoint(ep.LeagueDashLineups),
     DeferredEndpoint(ep.LeagueDashOppPtShot),

--- a/tools/stats/library/mapping.py
+++ b/tools/stats/library/mapping.py
@@ -58,6 +58,7 @@ endpoint_list = [
     "HomePageV2",
     "HustleStatsBoxScore",
     "InfographicFanDuelPlayer",
+    "ISTStandings",
     "LeadersTiles",
     "LeagueDashLineups",
     "LeagueDashOppPtShot",
@@ -2530,6 +2531,11 @@ parameter_map = {
             "^(\\d{4}-\\d{2})|(All Time)$": "SeasonAll_Time",
             "^(\\d{4}-\\d{2})|(\\d{4})$": "Season",
         },
+    },
+    "Section": {
+        "non-nullable": {
+            "^(group)|(wildcard)$": "Section"
+        }
     },
     "SeriesID": {"nullable": {None: "SeriesIDNullable"}, "non-nullable": {}},
     "ShotClockRange": {


### PR DESCRIPTION
@rsforbes 
Hello, I want to add a new endpoint for the In-Season Tournament: ISTStandings
![Снимок экрана от 2023-11-08 11-06-54](https://github.com/swar/nba_api/assets/49508936/3bfa635f-2e7e-429a-8e56-31567a977f0b)

I want to note that the endpoint accepts the Season parameter only in the format \\d{4}-\\d{2}, so I added 20 in front. I think everyone is used to writing only the last two digits of the seasons (23-24).