### PR TITLE
update ScoreBoard game_date property name to score_board_date

### DIFF
--- a/docs/nba_api/live/endpoints/scoreboard.md
+++ b/docs/nba_api/live/endpoints/scoreboard.md
@@ -8,10 +8,10 @@
 `None`
 
 ## Properties
-#### GameDate `game_date`
+#### GameDate `score_board_date`
 ```text
 #returns a string
-scoreboard.ScoreBoard().game_date
+scoreboard.ScoreBoard().score_board_date
 ```
 
 #### Games `games`


### PR DESCRIPTION
minor PR but it looks like there's a mismatch in the [documented property name for the game in `ScoreBoard()`](https://github.com/swar/nba_api/blob/5853b5469c436d9489ef355235209daa3a300bba/docs/nba_api/live/endpoints/scoreboard.md#gamedate-game_date), [and the implementation](https://github.com/swar/nba_api/blob/5853b5469c436d9489ef355235209daa3a300bba/src/nba_api/live/nba/endpoints/scoreboard.py#L107). The docs say `.game_date` but it's implemented as `.score_board_date`. Alternatively, I can instead change what's in https://github.com/swar/nba_api/blob/5853b5469c436d9489ef355235209daa3a300bba/src/nba_api/live/nba/endpoints/scoreboard.py to switch from `scoreboard_game_date` to `game_data` but I figured this change to the docs would be less risky.