### PR TITLE
Fix BoxScoreTraditionalV3 API Bug(some game stats starters and bench is None, cause 'NoneType' object has no attribute 'values')

### DIFF
--- a/src/nba_api/stats/library/parserv3.py
+++ b/src/nba_api/stats/library/parserv3.py
@@ -141,24 +141,32 @@ class NBAStatsBoxscoreTraditionalParserV3(NBAStatsBoxscoreParserV3):
             for key, value in raw_dict["homeTeam"].items()
             if key not in ("players", "statistics", "starters", "bench")
         ]
-        home_team_starter_stats = [
-            x for x in raw_dict["homeTeam"]["starters"].values()
-        ] + ["Starters"]
-        home_team_bench_stats = [x for x in raw_dict["homeTeam"]["bench"].values()] + [
-            "Bench"
-        ]
+        home_team_starter = raw_dict["homeTeam"]["starters"]
+        home_team_bench = raw_dict["homeTeam"]["bench"]
+        home_team_starter_stats = (
+            [x for x in home_team_starter.values()] + ["Starters"]
+            if home_team_starter is not None else ["Starters"]
+        )
+        home_team_bench_stats = (
+            [x for x in home_team_bench.values()] + ["Bench"]
+            if home_team_bench is not None else ["Bench"]
+        )
 
         away_team_info = [
             value
             for key, value in raw_dict["awayTeam"].items()
             if key not in ("players", "statistics", "starters", "bench")
         ]
-        away_team_starter_stats = [
-            x for x in raw_dict["awayTeam"]["starters"].values()
-        ] + ["Starters"]
-        away_team_bench_stats = [x for x in raw_dict["awayTeam"]["bench"].values()] + [
-            "Bench"
-        ]
+        away_team_starter = raw_dict["awayTeam"]["starters"]
+        away_team_bench = raw_dict["awayTeam"]["bench"]
+        away_team_starter_stats = (
+            [x for x in away_team_starter.values()] + ["Starters"]
+            if away_team_starter is not None else ["Starters"]
+        )
+        away_team_bench_stats = (
+            [x for x in away_team_bench.values()] + ["Bench"]
+            if away_team_bench is not None else ["Bench"]
+        )
 
         return [
             [raw_dict["gameId"]] + home_team_info + home_team_starter_stats,


### PR DESCRIPTION
For example:
endpoint is : `boxscoretraditionalv3`
Game `0012300001`, period `4`, params is: 
``` python
  params = {
    'game_id': '0012300001',
    'range_type': 1,
    'start_period': 4,
    'end_period': 4,
  }
```
NBA official Website response is like this(starters and bench is null):
![image](https://github.com/user-attachments/assets/f06d99ce-9fbc-4c7a-abc5-127f85530a91)


but nba_api will throw an error:
```
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nba_api/stats/endpoints/boxscoretraditionalv3.py", line 141, in __init__
    self.get_request()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nba_api/stats/endpoints/boxscoretraditionalv3.py", line 151, in get_request
    self.load_response()
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nba_api/stats/endpoints/boxscoretraditionalv3.py", line 154, in load_response
    data_sets = self.nba_response.get_data_sets(self.endpoint)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nba_api/stats/library/http.py", line 150, in get_data_sets
    return endpoint_parser.get_data_sets()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nba_api/stats/library/parserv3.py", line 234, in get_data_sets
    start_bench_data = self.get_start_bench_data()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/nba_api/stats/library/parserv3.py", line 145, in get_start_bench_data
    x for x in raw_dict["homeTeam"]["starters"].values()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'values'
```