### PR TITLE
Update expired Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Downloads per Month: PyPY](https://img.shields.io/pypi/dm/nba_api.svg?style=for-the-badge)](https://pepy.tech/project/nba-api)
 [![Build: CircleCI](https://img.shields.io/circleci/project/github/swar/nba_api.svg?style=for-the-badge&logo=circleci)](https://circleci.com/gh/swar/nba_api)
 [![License: MIT](https://img.shields.io/github/license/swar/nba_api.svg?style=for-the-badge)](https://github.com/swar/nba_api/blob/master/LICENSE)
-[![Slack](https://img.shields.io/badge/Slack-NBA_API-4A154B?style=for-the-badge&logo=slack)](https://join.slack.com/t/nbaapi/shared_invite/zt-2c18itntt-ObWh0ovNQmnwLGFagmCbpg)
+[![Slack](https://img.shields.io/badge/Slack-NBA_API-4A154B?style=for-the-badge&logo=slack)](https://join.slack.com/t/nbaapi/shared_invite/zt-2svs1m40l-aeS5c0PQpft9qSh1mPXC~w)
 
 # nba_api
 


### PR DESCRIPTION
Updated the expired Slack link with an expiration date of 30 days (Note: I'm not sure if that's the appropriate expiration length)