### PR TITLE
Make Playtype and TypeGrouping variables non-nullable

### DIFF
--- a/docs/nba_api/stats/endpoints/synergyplaytypes.md
+++ b/docs/nba_api/stats/endpoints/synergyplaytypes.md
@@ -62,11 +62,10 @@
     "parameter_patterns": {
         "LeagueID": "^\\d{2}$",
         "PerMode": "^(Totals)|(PerGame)$",
-        "PlayType": null,
         "PlayerOrTeam": "^(P)|(T)$",
         "SeasonType": "^(Regular Season)|(Pre Season)|(Playoffs)|(All Star)|(All-Star)$",
         "SeasonYear": "^(\\d{4}-\\d{2})|(\\d{4})$",
-        "TypeGrouping": null
+        "TypeGrouping": "^(offensive)|(defensive)$",
         "PlayType": "^(Cut)|(Handoff)|(Isolation)|(Misc)|(Offscreen)|(Postup)|(PRBallHandler)|(PRRollman)|(OffRebound)|(Spotup)|(Transition)$"
     },
     "parameters": [
@@ -77,14 +76,15 @@
         "SeasonType",
         "SeasonYear",
         "TypeGrouping",
-        "PlayType"
     ],
     "required_parameters": [
         "LeagueID",
         "PerMode",
+        "PlayType",
         "PlayerOrTeam",
         "SeasonType",
-        "SeasonYear"
+        "SeasonYear",
+        "TypeGrouping",
     ],
     "status": "success"
 }

--- a/docs/nba_api/stats/endpoints/synergyplaytypes.md
+++ b/docs/nba_api/stats/endpoints/synergyplaytypes.md
@@ -15,8 +15,8 @@
 | [_**PlayerOrTeam**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#PlayerOrTeam) | player_or_team_abbreviation |                              `^(P)\|(T)$`                              |   `Y`    |          | 
 | [_**SeasonType**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#SeasonType)     | season_type_all_star        | `^(Regular Season)\|(Pre Season)\|(Playoffs)\|(All Star)\|(All-Star)$` |   `Y`    |          | 
 | [_**SeasonYear**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#SeasonYear)     | season                      |                       `^(\d{4}-\d{2})\|(\d{4})$`                       |   `Y`    |          | 
-| [_**TypeGrouping**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#TypeGrouping) | type_grouping_nullable      |                                                                        |          |   `Y`    | 
-| [_**PlayType**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#PlayType)         | play_type_nullable          |                                                                        |   `Y`    |          | 
+| [_**TypeGrouping**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#TypeGrouping) | type_grouping               |                      `^(offensive)|(defensive)$`                       |   `Y`    |          |
+| [_**PlayType**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#PlayType)         | play_type                   |                                                                        |   `Y`    |          | 
 
 ## Data Sets
 #### SynergyPlayType `synergy_play_type`

--- a/docs/nba_api/stats/endpoints/synergyplaytypes.md
+++ b/docs/nba_api/stats/endpoints/synergyplaytypes.md
@@ -16,7 +16,7 @@
 | [_**SeasonType**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#SeasonType)     | season_type_all_star        | `^(Regular Season)\|(Pre Season)\|(Playoffs)\|(All Star)\|(All-Star)$` |   `Y`    |          | 
 | [_**SeasonYear**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#SeasonYear)     | season                      |                       `^(\d{4}-\d{2})\|(\d{4})$`                       |   `Y`    |          | 
 | [_**TypeGrouping**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#TypeGrouping) | type_grouping_nullable      |                                                                        |          |   `Y`    | 
-| [_**PlayType**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#PlayType)         | play_type_nullable          |                                                                        |          |   `Y`    | 
+| [_**PlayType**_](https://github.com/swar/nba_api/blob/master/docs/nba_api/stats/library/parameters.md#PlayType)         | play_type_nullable          |                                                                        |   `Y`    |          | 
 
 ## Data Sets
 #### SynergyPlayType `synergy_play_type`
@@ -55,9 +55,8 @@
         ]
     },
     "endpoint": "SynergyPlayTypes",
-    "last_validated_date": "2020-08-15",
+    "last_validated_date": "2025-01-22",
     "nullable_parameters": [
-        "PlayType",
         "TypeGrouping"
     ],
     "parameter_patterns": {
@@ -68,6 +67,7 @@
         "SeasonType": "^(Regular Season)|(Pre Season)|(Playoffs)|(All Star)|(All-Star)$",
         "SeasonYear": "^(\\d{4}-\\d{2})|(\\d{4})$",
         "TypeGrouping": null
+        "PlayType": "^(Cut)|(Handoff)|(Isolation)|(Misc)|(Offscreen)|(Postup)|(PRBallHandler)|(PRRollman)|(OffRebound)|(Spotup)|(Transition)$"
     },
     "parameters": [
         "LeagueID",
@@ -76,7 +76,8 @@
         "PlayerOrTeam",
         "SeasonType",
         "SeasonYear",
-        "TypeGrouping"
+        "TypeGrouping",
+        "PlayType"
     ],
     "required_parameters": [
         "LeagueID",

--- a/src/nba_api/stats/endpoints/synergyplaytypes.py
+++ b/src/nba_api/stats/endpoints/synergyplaytypes.py
@@ -53,7 +53,7 @@ class SynergyPlayTypes(Endpoint):
         player_or_team_abbreviation=PlayerOrTeamAbbreviation.default,
         season_type_all_star=SeasonTypeAllStar.default,
         season=Season.default,
-        play_type_nullable=PlayTypeNullable.default,
+        play_type=PlayTypeNullable.default,
         type_grouping_nullable=TypeGroupingNullable.default,
         proxy=None,
         headers=None,
@@ -70,7 +70,7 @@ class SynergyPlayTypes(Endpoint):
             "PlayerOrTeam": player_or_team_abbreviation,
             "SeasonType": season_type_all_star,
             "SeasonYear": season,
-            "PlayType": play_type_nullable,
+            "PlayType": play_type,
             "TypeGrouping": type_grouping_nullable,
         }
         if get_request:

--- a/src/nba_api/stats/endpoints/synergyplaytypes.py
+++ b/src/nba_api/stats/endpoints/synergyplaytypes.py
@@ -6,8 +6,8 @@ from nba_api.stats.library.parameters import (
     PlayerOrTeamAbbreviation,
     SeasonTypeAllStar,
     Season,
-    PlayTypeNullable,
-    TypeGroupingNullable,
+    PlayType,
+    TypeGrouping,
 )
 
 
@@ -53,8 +53,8 @@ class SynergyPlayTypes(Endpoint):
         player_or_team_abbreviation=PlayerOrTeamAbbreviation.default,
         season_type_all_star=SeasonTypeAllStar.default,
         season=Season.default,
-        play_type=PlayTypeNullable.default,
-        type_grouping_nullable=TypeGroupingNullable.default,
+        play_type=PlayType.default,
+        type_grouping=TypeGrouping.default,
         proxy=None,
         headers=None,
         timeout=30,
@@ -71,7 +71,7 @@ class SynergyPlayTypes(Endpoint):
             "SeasonType": season_type_all_star,
             "SeasonYear": season,
             "PlayType": play_type,
-            "TypeGrouping": type_grouping_nullable,
+            "TypeGrouping": type_grouping,
         }
         if get_request:
             self.get_request()


### PR DESCRIPTION
Enhance data integrity: Make variables non-nullable to ensure DataFrames are always populated and prevent unexpected empty results. The None option is redundant in this context.