### PR TITLE
import ScheduleLeagueV2 into __init__.py

### DIFF
--- a/src/nba_api/stats/endpoints/__init__.py
+++ b/src/nba_api/stats/endpoints/__init__.py
@@ -242,6 +242,7 @@ from .playernextngames import PlayerNextNGames
 from .playerprofilev2 import PlayerProfileV2
 from .playervsplayer import PlayerVsPlayer
 from .playoffpicture import PlayoffPicture
+from .scheduleleaguev2 import ScheduleLeagueV2
 from .scoreboardv2 import ScoreboardV2
 from .shotchartdetail import ShotChartDetail
 from .shotchartleaguewide import ShotChartLeagueWide


### PR DESCRIPTION
This was needed for me to `from nba_api.stats.endpoints import ScheduleLeagueV2`