### PR TITLE
fix: handle missing WinProbability data in ScoreboardV2 endpoint

### DIFF
--- a/src/nba_api/stats/endpoints/scoreboardv2.py
+++ b/src/nba_api/stats/endpoints/scoreboardv2.py
@@ -187,4 +187,5 @@ class ScoreboardV2(Endpoint):
         self.west_conf_standings_by_day = Endpoint.DataSet(
             data=data_sets["WestConfStandingsByDay"]
         )
-        self.win_probability = Endpoint.DataSet(data=data_sets["WinProbability"])
+        if "WinProbability" in data_sets:
+            self.win_probability = Endpoint.DataSet(data=data_sets["WinProbability"])


### PR DESCRIPTION
#528 