### PR TITLE
build: add local release preparation script and workflow

### DIFF
--- a/RELEASE_TESTING.md
+++ b/RELEASE_TESTING.md
@@ -8,9 +8,23 @@ The NBA API uses [semantic-release](https://semantic-release.gitbook.io/) for au
 
 ## Testing Methods
 
-### 1. Local Testing (Safest)
+### 1. Using the Release Script (Recommended)
 
-Since developers work on branches (not `master`), `semantic-release version --print` will always show "no release will be made". Here are better local testing methods:
+The easiest way to prepare a release is using the provided script:
+
+```bash
+# From project root
+./scripts/gen-release.sh
+```
+
+This script will:
+- Check you're on a release-compatible branch (or offer to create one)
+- Determine the next version based on conventional commits
+- Update version in pyproject.toml and CHANGELOG.MD
+- Create a local commit (but not push)
+- Provide instructions for creating a PR
+
+### 2. Local Testing (Manual)
 
 ```bash
 # Install dependencies
@@ -43,7 +57,7 @@ git checkout your_branch_name
 - Validates conventional commit format
 - Tests actual semantic-release logic (Method 3)
 
-### 2. Fork Testing (Recommended for Full Workflow)
+### 3. Fork Testing (Full Workflow)
 
 For complete workflow testing following the standard fork workflow:
 
@@ -81,7 +95,7 @@ git push origin --delete your_branch_name
 - No disruption to your fork's master branch
 - Tests real workflow that contributors use
 
-### 3. Commit Type Testing
+### 4. Commit Type Testing
 
 Test different conventional commit types to see version impacts:
 
@@ -154,7 +168,8 @@ This message appears when:
 
 ### Testing on Wrong Branch
 Make sure you're on the correct branch:
-- `master` - Production releases  
+- `master` or `main` - Production releases
+- `release`, `prepare-release`, or `release/*` - Local release preparation (supported by gen-release.sh)
 - Other branches - No release jobs run (testing should be done locally or on forks)
 
 ### Version Not Updating Locally
@@ -172,32 +187,37 @@ git log --oneline --grep="feat\|fix\|BREAKING" $(git describe --tags --abbrev=0)
 
 ## Best Practices
 
-1. **Always test locally first** using manual commit analysis
-2. **Use fork workflow** for full workflow validation
-3. **Follow conventional commit format** in your commits
-4. **Clean up test branches** after testing
-5. **Document any issues** you encounter during testing
+1. **Use the gen-release.sh script** for preparing releases locally
+2. **Always test locally first** using manual commit analysis
+3. **Use fork workflow** for full workflow validation
+4. **Follow conventional commit format** in your commits
+5. **Clean up test branches** after testing
+6. **Document any issues** you encounter during testing
 
 ## Example Test Workflow
 
 ```bash
-# 1. Test locally first
+# 1. Use the release script (easiest)
+./scripts/gen-release.sh
+# Follow the prompts to prepare release
+
+# 2. Or test manually:
 git commit -m "feat: add new testing feature" --allow-empty
 git commit -m "fix: resolve testing issue" --allow-empty
 
-# 2. Check what would be released
+# 3. Check what would be released
 poetry run semantic-release version --print
 # Should show: 1.11.0 (minor bump for feat)
 
-# 3. Test version bump without publishing
-poetry run semantic-release version --no-push --no-vcs-release
+# 4. Test version bump without publishing
+poetry run semantic-release version --no-push --no-vcs-release --no-tag
 # Updates local files to show what would happen
 
-# 4. Reset changes and clean up
+# 5. Reset changes and clean up
 git reset --hard HEAD~2
 # Removes test commits
 
-# 5. For full workflow testing, use your fork:
+# 6. For full workflow testing, use your fork:
 # Fork repo → push changes → observe complete automation
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ token = { env = "GITHUB_TOKEN" }
 match = "(master|main)"
 prerelease = false
 
+[tool.semantic_release.branches.release]
+match = "(release|release/.*)"
+prerelease = false
+
 [tool.semantic_release.branches.test]
 match = "test-release"
 prerelease = true
@@ -94,14 +98,11 @@ minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 
 [tool.semantic_release.changelog]
-template_dir = "templates"
 exclude_commit_patterns = [
   "^Bump .*",
   "^Update .*", 
   "^Merge pull request.*"
 ]
-
-[tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.MD"
 
 [tool.semantic_release.changelog.environment]

--- a/scripts/gen-release.sh
+++ b/scripts/gen-release.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# Script to prepare a release for nba_api
+# This automates the changelog generation and version bumping process
+# for contributors working on forks
+
+set -e  # Exit on error
+
+# Wrap everything in a function to avoid exit statements
+run_release_prep() {
+    echo "NBA API Release Preparation Script"
+    echo "======================================"
+    echo ""
+
+    # Check if we're in the project root
+    if [ ! -f "pyproject.toml" ]; then
+        echo "Error: pyproject.toml not found. Please run this script from the project root."
+        return 1
+    fi
+
+    # Check if poetry is available
+    if ! command -v poetry &> /dev/null; then
+        echo "Error: poetry is not installed. Please install poetry first."
+        return 1
+    fi
+
+    # Check current branch
+    CURRENT_BRANCH=$(git branch --show-current)
+    echo "Current branch: $CURRENT_BRANCH"
+
+    # Check if we're on a release-compatible branch
+    if [[ ! "$CURRENT_BRANCH" =~ ^(release|release/.*) ]]; then
+        echo ""
+        echo "Warning: You're not on a release branch."
+        echo "Semantic-release is configured to work on: release or release/*"
+        echo ""
+        read -p "Do you want to create a 'release' branch? (y/n): " -n 1 -r
+        echo ""
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            git checkout -b release
+            echo "Switched to 'release' branch"
+        else
+            echo "Aborted. Please switch to a release branch first."
+            return 1
+        fi
+    fi
+
+    # Check for uncommitted changes
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Warning: You have uncommitted changes."
+        git status --short
+        echo ""
+        read -p "Do you want to continue anyway? (y/n): " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Aborted. Please commit or stash your changes first."
+            return 1
+        fi
+    fi
+
+    # Determine what version will be created
+    echo ""
+    echo "Analyzing commits to determine next version..."
+    NEXT_VERSION=$(poetry run semantic-release version --print 2>/dev/null || echo "")
+
+    if [ -z "$NEXT_VERSION" ]; then
+        echo "Error: Could not determine next version."
+        echo "This might mean:"
+        echo "  - No commits requiring a version bump since last release"
+        echo "  - Branch is not properly configured in pyproject.toml"
+        return 1
+    fi
+
+    echo "Next version will be: $NEXT_VERSION"
+    echo ""
+
+    # Ask for confirmation
+    read -p "Do you want to proceed with release preparation for v$NEXT_VERSION? (y/n): " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted by user."
+        return 1
+    fi
+
+    # Run semantic-release
+    echo ""
+    echo "Running semantic-release to update version and changelog..."
+    echo "This will:"
+    echo "  - Update version in pyproject.toml"
+    echo "  - Generate/update CHANGELOG.MD"
+    echo "  - Create a local commit"
+    echo "  - NOT create a git tag"
+    echo "  - NOT push to remote"
+    echo ""
+
+    poetry run semantic-release version --no-tag --no-push --no-vcs-release
+
+    # Check if it succeeded
+    if [ $? -eq 0 ]; then
+        echo ""
+        echo "Release preparation completed successfully!"
+        echo ""
+        echo "Changes made:"
+        git diff HEAD~1 --name-only
+        echo ""
+        echo "Next steps:"
+        echo "  1. Review the changes: git diff HEAD~1"
+        echo "  2. Push to your fork: git push origin $(git branch --show-current)"
+        echo "  3. Create a PR to upstream/master with title: 'chore: release v$NEXT_VERSION'"
+        echo "  4. After PR is merged, from clean master branch:"
+        echo "     - git checkout master && git pull upstream master"
+        echo "     - poetry build"
+        echo "     - poetry publish"
+    else
+        echo ""
+        echo "Error: semantic-release failed."
+        echo "Check the error messages above for details."
+        return 1
+    fi
+}
+
+# Run the function
+run_release_prep


### PR DESCRIPTION
- Add gen-release.sh script to automate changelog and version bumping
- Configure semantic-release to work on release branches for fork workflow
- Update RELEASE_TESTING.md with new script documentation
- Simplify branch configuration to use release and release/* patterns

This enables contributors to prepare releases locally without CI/CD access, following a fork-based workflow where releases are built from master after PR merge.