### PR TITLE
fix: improve error handling for invalid API responses

### DIFF
--- a/src/nba_api/library/http.py
+++ b/src/nba_api/library/http.py
@@ -39,7 +39,21 @@ class NBAResponse:
         return self._response
 
     def get_dict(self):
-        return json.loads(self._response)
+        try:
+            return json.loads(self._response)
+        except json.JSONDecodeError as e:
+            if not self._response or self._response.isspace():
+                raise ValueError(
+                    f"NBA API returned an empty response. "
+                    f"This can happen for various reasons including no data available for the requested parameters. "
+                    f"URL: {self._url}"
+                ) from e
+            else:
+                raise ValueError(
+                    f"NBA API returned an invalid JSON response: {str(e)}. "
+                    f"Response content (first 200 chars): {self._response[:200]}... "
+                    f"URL: {self._url}"
+                ) from e
 
     def get_json(self):
         return json.dumps(self.get_dict())


### PR DESCRIPTION
# Error Handling Improvement

This PR improves error handling when the NBA API returns invalid or empty responses.

## Problem

The NBA API sometimes returns non-JSON responses for certain date/parameter combinations:
- Empty responses for dates with no data
- 500 Internal Server Error messages wrapped in plain text
- Previously resulted in cryptic `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`

## Solution

Enhanced `NBAResponse.get_dict()` in `src/nba_api/library/http.py` to:
- Catch `JSONDecodeError` and provide informative error messages
- Show preview of response content when invalid JSON is received
- Include the request URL for easier debugging
- Differentiate between empty responses and responses with error content

## Example

**Before:**
```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

**After:**
```
ValueError: NBA API returned an invalid JSON response: Expecting value: line 1 column 1 (char 0). 
Response content (first 200 chars): System.Net.WebException: The remote server returned an error: (500) Internal Server Error...
URL: https://stats.nba.com/stats/playerdashptreb?...
```

## Testing

- All 460 existing unit tests pass
- Tested with various date/season combinations showing different API quirks