### PR TITLE
Remove deprecated PF context measure from ContextMeasureSimple

### DIFF
--- a/src/nba_api/stats/library/parameters.py
+++ b/src/nba_api/stats/library/parameters.py
@@ -95,7 +95,6 @@ class ConferenceNullable(_NotRequired, Conference):
 
 
 class ContextMeasureSimple(_ContextMeasure):
-    pf = "PF"
     efg_pct = "EFG_PCT"
     ts_pct = "TS_PCT"
 


### PR DESCRIPTION
## Summary
This PR removes the `PF` (Personal Fouls) context measure from the `ContextMeasureSimple` class as it has been deprecated by the NBA.com API.

## Issue
Fixes #600

## Details
The NBA.com API endpoint for `shotchartdetail` no longer returns data when using `PF` as a context measure. Other context measures such as `FGA`, `FGM`, `PTS`, `EFG_PCT`, and `TS_PCT` continue to function correctly.

This appears to be a backend change by the NBA, as Personal Fouls are not a relevant metric for filtering shot chart data (which focuses on shooting statistics).

## Changes
- Removed `pf = "PF"` from the `ContextMeasureSimple` class in `src/nba_api/stats/library/parameters.py`

## Testing
Users who were experiencing issues with the `PF` context measure returning no data should no longer be able to use this deprecated parameter, preventing confusion and API errors.