### PR TITLE
Add __version__ attribute to package

### DIFF
--- a/src/nba_api/__init__.py
+++ b/src/nba_api/__init__.py
@@ -1,1 +1,4 @@
+from importlib.metadata import version
+
 name = "nba_api"
+__version__ = version("nba_api")

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,18 @@
+import nba_api
+from importlib.metadata import version
+
+
+def test_version_exists():
+    assert hasattr(nba_api, '__version__')
+
+
+def test_version_format():
+    assert isinstance(nba_api.__version__, str)
+    parts = nba_api.__version__.split('.')
+    assert len(parts) >= 2
+    for part in parts:
+        assert part.isdigit()
+
+
+def test_version_matches_metadata():
+    assert nba_api.__version__ == version("nba_api")


### PR DESCRIPTION
Expose package version via `__version__` attribute using `importlib.metadata` with `pyproject.toml` as single source of truth.

Includes unit tests to verify version attribute exists, has correct format, and matches package metadata.

Reference: [PEP 396 - Module Version Numbers](https://peps.python.org/pep-0396/)