### PR TITLE
feat: add clear_session() to NBAHTTP

### DIFF
--- a/src/nba_api/library/http.py
+++ b/src/nba_api/library/http.py
@@ -78,6 +78,12 @@ class NBAHTTP:
     def set_session(cls, session) -> None:
         cls._session = session
 
+    @classmethod
+    def clear_session(cls) -> None:
+        if cls._session is not None:
+            cls._session.close()
+            cls._session = None
+
     def clean_contents(self, contents):
         return contents
 


### PR DESCRIPTION
- Introduce a public method to close and clear the internal _session.

- Allows users to drop rate-limited cookies.

- Prevents potential memory leaks by explicitly closing underlying TCP connections.

Motivated by issues thread: https://github.com/swar/nba_api/issues/633. 