### PR TITLE
fix: add nba.com Referer header to live endpoint requests

### DIFF
--- a/src/nba_api/live/nba/library/http.py
+++ b/src/nba_api/live/nba/library/http.py
@@ -10,6 +10,7 @@ except ImportError:
         "Cache-Control": "max-age=0",
         "Connection": "keep-alive",
         "Host": "cdn.nba.com",
+        "Referer": "https://www.nba.com/",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
     }
 


### PR DESCRIPTION
## Summary
`cdn.nba.com` started returning `403` for `liveData` requests that don't carry an `nba.com` `Referer` header, which breaks the `live` endpoints (`ScoreBoard`, `PlayByPlay`, `BoxScore`, `Odds`). The `stats` HTTP client already sends `Referer: https://www.nba.com/`; this adds the same header to the `live` client's default headers.

Fixes #670

## Change
- `src/nba_api/live/nba/library/http.py`: add `"Referer": "https://www.nba.com/"` to the `STATS_HEADERS` fallback dict.

## Verification
```python
from nba_api.live.nba.endpoints import boxscore
boxscore.BoxScore("0022200720").get_dict()  # 200 again instead of 403
```
`pytest tests/unit/live tests/unit/http` passes (the 2 `test_get_request_url` failures are pre-existing on `master` — they hit the live CDN with a stale 2021 game id, unrelated to this change).