### PR TITLE
fix: add Guangzhou Loong Lions to static teams (#622)

### DIFF
--- a/src/nba_api/stats/library/data.py
+++ b/src/nba_api/stats/library/data.py
@@ -6272,6 +6272,16 @@ team_index_state = 6
 team_index_championship_year = 7
 
 teams = [
+    [
+        15018,
+        "GUA",
+        "Loong Lions",
+        2000,
+        "Guangzhou",
+        "Guangzhou Loong Lions",
+        "Guangdong",
+        [],
+    ],
     [1610612737, "ATL", "Hawks", 1949, "Atlanta", "Atlanta Hawks", "Georgia", [1958]],
     [
         1610612738,

--- a/tests/unit/stats/static/test_static_data.py
+++ b/tests/unit/stats/static/test_static_data.py
@@ -2,8 +2,19 @@ from nba_api.stats.static import teams
 
 
 def test_nba_teams():
-    assert len(teams.teams) == 30
+    assert len(teams.teams) == 31
 
 
 def test_wnba_teams():
     assert len(teams.wnba_teams) == 13
+
+
+def test_find_team_by_abbreviation():
+    gua = teams.find_team_by_abbreviation("GUA")
+    assert gua is not None
+    assert gua["id"] == 15018
+    assert gua["full_name"] == "Guangzhou Loong Lions"
+    assert gua["nickname"] == "Loong Lions"
+    assert gua["city"] == "Guangzhou"
+    assert gua["state"] == "Guangdong"
+    assert gua["year_founded"] == 2000


### PR DESCRIPTION
Resolves open issue #622 by adding the Guangzhou Loong Lions (CBA team) to the static teams database.

Fixes #622

* Added Guangzhou Loong Lions to the static `teams` list in `data.py`.
* Updated the unit test `test_nba_teams` count check from `30` to `31` and added a new unit test validating team lookup by abbreviation "GUA".