### PR TITLE
Fix/test session isolation and mocks

### DIFF
--- a/src/nba_api/library/http.py
+++ b/src/nba_api/library/http.py
@@ -68,15 +68,15 @@ class NBAHTTP:
 
     @classmethod
     def get_session(cls):
-        session = cls._session
+        session = NBAHTTP._session
         if session is None:
             session = requests.Session()
-            cls._session = session
+            NBAHTTP._session = session
         return session
 
     @classmethod
     def set_session(cls, session) -> None:
-        cls._session = session
+        NBAHTTP._session = session
 
     def clean_contents(self, contents):
         return contents

--- a/tests/unit/live/endpoints/test_live_boxscore.py
+++ b/tests/unit/live/endpoints/test_live_boxscore.py
@@ -486,7 +486,7 @@ def nba_http_patch(monkeypatch):
     monkeypatch.setattr(NBAHTTP, "send_api_request", MockResponse.send_api_request)
 
 
-def test_get_request_url():
+def test_get_request_url(nba_http_patch):
     assert (
         boxscore.BoxScore(game_id).get_request_url()
         == "https://cdn.nba.com/static/json/liveData/boxscore/boxscore_0022000180.json"

--- a/tests/unit/live/endpoints/test_live_odds.py
+++ b/tests/unit/live/endpoints/test_live_odds.py
@@ -416,7 +416,7 @@ def nba_http_patch(monkeypatch):
     monkeypatch.setattr(NBAHTTP, "send_api_request", MockResponse.send_api_request)
 
 
-def test_get_request_url():
+def test_get_request_url(nba_http_patch):
     assert (
         odds.Odds().get_request_url()
         == "https://cdn.nba.com/static/json/liveData/odds/odds_todaysGames.json"


### PR DESCRIPTION
Resolves 3 existing unit test failures on `master` related to session isolation and unmocked endpoint URL tests.

* Modified the `NBAHTTP.get_session`/`set_session` to explicitly reference `NBAHTTP._session` to prevent subclasses from shadowing the global session and leaking the state
* Added the `nba_http_patch` fixture to the signatures of live boxscore and live odds tests to ensure they are fully mocked and isolated from the CDN network.