### PR TITLE
fix: mock HTTP layer in live boxscore/odds get_request_url tests

### DIFF
--- a/tests/unit/live/endpoints/test_live_boxscore.py
+++ b/tests/unit/live/endpoints/test_live_boxscore.py
@@ -486,7 +486,7 @@ def nba_http_patch(monkeypatch):
     monkeypatch.setattr(NBAHTTP, "send_api_request", MockResponse.send_api_request)
 
 
-def test_get_request_url():
+def test_get_request_url(nba_http_patch):
     assert (
         boxscore.BoxScore(game_id).get_request_url()
         == "https://cdn.nba.com/static/json/liveData/boxscore/boxscore_0022000180.json"

--- a/tests/unit/live/endpoints/test_live_odds.py
+++ b/tests/unit/live/endpoints/test_live_odds.py
@@ -416,7 +416,7 @@ def nba_http_patch(monkeypatch):
     monkeypatch.setattr(NBAHTTP, "send_api_request", MockResponse.send_api_request)
 
 
-def test_get_request_url():
+def test_get_request_url(nba_http_patch):
     assert (
         odds.Odds().get_request_url()
         == "https://cdn.nba.com/static/json/liveData/odds/odds_todaysGames.json"


### PR DESCRIPTION
test_get_request_url in test_live_boxscore.py and test_live_odds.py was missing the nba_http_patch fixture that every other test in these files uses, so it made a real network call to cdn.nba.com. This is flaky in CI when the CDN blocks/rate-limits the runner IP, returning an HTML "Access Denied" page instead of JSON.